### PR TITLE
star-info: add star discovery buff

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'com.starinfo'
-version = '1.2.0'
+version = '1.3.0'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/com/starinfo/BonusCounter.java
+++ b/src/main/java/com/starinfo/BonusCounter.java
@@ -1,0 +1,30 @@
+package com.starinfo;
+
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.ui.overlay.infobox.Counter;
+import javax.annotation.Nonnull;
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+
+public class BonusCounter extends Counter
+{
+	private final StarInfoPlugin plugin;
+
+	public BonusCounter(BufferedImage image, @Nonnull Plugin plugin, int bonus)
+	{
+		super(image, plugin, bonus);
+		this.plugin = (StarInfoPlugin) plugin;
+	}
+
+	@Override
+	public String getText()
+	{
+		return String.valueOf(plugin.bonusCount);
+	}
+
+	@Override
+	public Color getTextColor()
+	{
+		return Color.WHITE;
+	}
+}

--- a/src/main/java/com/starinfo/StarInfoConfig.java
+++ b/src/main/java/com/starinfo/StarInfoConfig.java
@@ -40,6 +40,7 @@ public interface StarInfoConfig extends Config
 	String TEXT_COLOR_KEY = "textColor";
 	String THICK_OUTLINE = "thickOutline";
 	String INFO_BOX_KEY = "infoBox";
+	String BONUS_INFO_BOX_KEY = "showStarDiscovery";
 	String HINT_ARROW_KEY = "hintArrow";
 	String SHOW_PERCENT = "showPercent";
 	String SHOW_DUST = "showDust";
@@ -181,6 +182,17 @@ public interface StarInfoConfig extends Config
 
 	@ConfigItem(
 		position = 14,
+		keyName = BONUS_INFO_BOX_KEY,
+		name = "Show Star Discovery",
+		description = "Whether to display star discovery boost info box"
+	)
+	default boolean showStarDiscovery()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+		position = 15,
 		keyName = HINT_ARROW_KEY,
 		name = "Show Hint Arrow",
 		description = "Whether to display hint arrow pointing to star"
@@ -191,7 +203,7 @@ public interface StarInfoConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 15,
+		position = 16,
 		keyName = COLOR_STAR,
 		name = "Highlight Star",
 		description = "Highlights stars green if you can mine it, and red if you can't"
@@ -202,7 +214,7 @@ public interface StarInfoConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 16,
+		position = 17,
 		keyName = CLIPBOARD,
 		name = "Copy to Clipboard Option",
 		description = "Allows you to right click stars and copy their information"
@@ -213,7 +225,7 @@ public interface StarInfoConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 17,
+		position = 18,
 		keyName = T0_IN_COPY,
 		name = "T0 Clipboard estimate",
 		description = "Adds time estimate till star is dead to copy option message"
@@ -224,7 +236,7 @@ public interface StarInfoConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 18,
+		position = 19,
 		keyName = ADD_TO_CHAT,
 		name = "Add Stars to Chat",
 		description = "Adds a message to the game chat when stars are found with their tier/world/location"
@@ -237,13 +249,13 @@ public interface StarInfoConfig extends Config
 	@ConfigSection(
 		name = "Health Bar",
 		description = "Settings for the health bar on stars",
-		position = 19,
+		position = 20,
 		closedByDefault = true
 	)
 	String healthBarSection = "healthBarSection";
 
 	@ConfigItem(
-		position = 20,
+		position = 21,
 		keyName = "hideHealthBar",
 		name = "Hide health bar",
 		section = healthBarSection,
@@ -259,7 +271,7 @@ public interface StarInfoConfig extends Config
 		max = 40
 	)
 	@ConfigItem(
-		position = 21,
+		position = 22,
 		keyName = "healthBarHeight",
 		name = "Health bar height",
 		section = healthBarSection,
@@ -275,7 +287,7 @@ public interface StarInfoConfig extends Config
 		max = 400
 	)
 	@ConfigItem(
-		position = 22,
+		position = 23,
 		keyName = "healthBarWidth",
 		name = "Health bar width",
 		section = healthBarSection,
@@ -288,7 +300,7 @@ public interface StarInfoConfig extends Config
 
 	@Alpha
 	@ConfigItem(
-		position = 23,
+		position = 24,
 		keyName = "hpColorFore",
 		name = "Hp left color",
 		section = healthBarSection,
@@ -301,7 +313,7 @@ public interface StarInfoConfig extends Config
 
 	@Alpha
 	@ConfigItem(
-		position = 24,
+		position = 25,
 		keyName = "hpColorBack",
 		name = "Hp background color",
 		section = healthBarSection,
@@ -317,7 +329,7 @@ public interface StarInfoConfig extends Config
 		max = 90
 	)
 	@ConfigItem(
-		position = 25,
+		position = 26,
 		keyName = REMOVE_DISTANCE,
 		name = "Remove distance",
 		description = "The tile distance above which star info is removed"


### PR DESCRIPTION
This PR adds an optional infobox for the buff players receive when first discovering a shooting star.

![image](https://github.com/pwatts6060/runelite-plugins/assets/50101641/c95384c3-43e9-4b62-8fbe-43e2cf50e40c)
