### PR TITLE
Updated version to 2.1.0, Added Lucid Poro to authors, Now works with wilderness agility dispenser and telegrab

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - Item quantities on the ground are only accurate up to 65534. 
 Picking up an item with quantity >= 65535 will show the bag value is at least the value it 
 thinks by showing a > symbol.
-- Works with wilderness agility dispenser
+- Works with wilderness agility dispenser and telegrab
 - May also track items in the following scenario:
     - You click on an item to take it
     - The item despawns by disappearance or someone else takes it

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - Item quantities on the ground are only accurate up to 65534. 
 Picking up an item with quantity >= 65535 will show the bag value is at least the value it 
 thinks by showing a > symbol.
-- Manually putting items from your inventory in the bag isn't supported.
+- Works with wilderness agility dispenser
 - May also track items in the following scenario:
     - You click on an item to take it
     - The item despawns by disappearance or someone else takes it

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'com.lootingbag'
-version = '2.0.1'
+version = '2.1.0'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -1,5 +1,5 @@
 displayName=Looting Bag
-author=Patrick,Nicole
+author=Patrick, Nicole, Lucid Poro
 support=https://github.com/pwatts6060/runelite-plugins/tree/looting-bag-value
 description=Overlays looting bag value / free spaces on the bag in inventory
 tags=looting,bag

--- a/src/main/java/com/lootingbag/LootingBagPlugin.java
+++ b/src/main/java/com/lootingbag/LootingBagPlugin.java
@@ -16,14 +16,9 @@ import javax.inject.Inject;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.*;
+import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
-import net.runelite.api.events.GameTick;
-import net.runelite.api.events.ItemContainerChanged;
-import net.runelite.api.events.ItemDespawned;
-import net.runelite.api.events.MenuOptionClicked;
-import net.runelite.api.events.VarClientIntChanged;
-import net.runelite.api.events.ChatMessage;
-import net.runelite.api.events.WidgetLoaded;
+import net.runelite.api.events.*;
 import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.InterfaceID;
 import net.runelite.api.widgets.Widget;
@@ -43,6 +38,8 @@ public class LootingBagPlugin extends Plugin
 	public static final int LOOTING_BAG_CONTAINER = 516;
 
 	private static final int LOOTING_BAG_SUPPLIES_SETTING_VARBIT_ID = 15310;
+
+	private static final int TELE_GRAB_PROJECTILE_ID = 143;
 
 	private static final Pattern WILDY_DISPENSER_REGEX = Pattern.compile("You have been awarded <[A-Za-z0-9=\\/]+>([\\d]+) x ([ a-zA-Z(4)]+)<[A-Za-z0-9=\\/]+> and <[A-Za-z0-9=\\/]+>([\\d]+) x ([ a-zA-Z]+)<[A-Za-z0-9=\\/]+> from the Agility dispenser.");
 	private static final Pattern WILDY_DISPENSER_EXTRA_REGEX = Pattern.compile("You have been awarded <[A-Za-z0-9=\\/]+>([\\d]+) x ([ a-zA-Z(4)]+)<[A-Za-z0-9=\\/]+> and <[A-Za-z0-9=\\/]+>([\\d]+) x ([ a-zA-Z]+)<[A-Za-z0-9=\\/]+>, and an extra <[A-Za-z0-9=\\/]+>[ a-zA-Z(4)]+<[A-Za-z0-9=\\/]+> from the Agility dispenser.");
@@ -76,6 +73,8 @@ public class LootingBagPlugin extends Plugin
 	private Gson gson;
 
 	private PickupAction lastPickUpAction;
+	private int telegrabPickUpCycle = -1;
+	private WorldPoint telegrabEndTile;
 
 	private int lastItemIdUsedOnLootingBag;
 
@@ -201,12 +200,47 @@ public class LootingBagPlugin extends Plugin
 			return;
 		}
 
-		// Take an item off the ground
-		if (event.getMenuAction() == MenuAction.GROUND_ITEM_THIRD_OPTION
-				&& event.getMenuOption().equals("Take")) {
+		// Telegrab item
+		boolean isTelegrab = false;
+		if (event.getMenuAction() == MenuAction.WIDGET_TARGET_ON_GROUND_ITEM ) {
+			List<String> widgetGroundItem = Arrays.asList(event.getMenuTarget().split(" -> "));
+			isTelegrab = widgetGroundItem.get(0).contains("Telekinetic Grab");
+			WorldPoint point = WorldPoint.fromScene(client, event.getParam0(), event.getParam1(), client.getPlane());
+			// get end tile based click, telegrab check in projectileMoved
+			telegrabEndTile = point;
+		}
+
+		boolean isTakeItemOffGround = event.getMenuAction() == MenuAction.GROUND_ITEM_THIRD_OPTION
+				&& event.getMenuOption().equals("Take");
+
+		// Take an item off the ground, or telegrab
+		if (isTakeItemOffGround || isTelegrab) {
 			WorldPoint point = WorldPoint.fromScene(client, event.getParam0(), event.getParam1(), client.getPlane());
 			lastPickUpAction = new PickupAction(event.getId(), point);
 		}
+	}
+
+	@Subscribe
+	public void onProjectileMoved(ProjectileMoved event) {
+		Player player = client.getLocalPlayer();
+		if (player == null) {
+			return;
+		}
+		boolean isTelegrab = event.getProjectile().getId() == TELE_GRAB_PROJECTILE_ID;
+		LocalPoint playerLocalPoint = player.getLocalLocation();
+		int wv = playerLocalPoint.getWorldView();
+		WorldView worldView = client.getWorldView(wv);
+		LocalPoint telegrabStartLocation = new LocalPoint(event.getProjectile().getX1(), event.getProjectile().getY1(), worldView);
+
+		WorldPoint playerWorldPoint = WorldPoint.fromLocal(client, playerLocalPoint);
+		WorldPoint telegrabWorldPoint = WorldPoint.fromLocal(client, telegrabStartLocation);
+
+		// not player's telegrab (telegrab start tile can be off by 5 if user is running/dragged around corners from what I can tell)
+		if (!(isTelegrab && telegrabWorldPoint.distanceTo(playerWorldPoint) <= 5)) {
+			return;
+		}
+
+		telegrabPickUpCycle = event.getProjectile().getEndCycle();
 	}
 
 	@Subscribe
@@ -226,7 +260,14 @@ public class LootingBagPlugin extends Plugin
 		WorldPoint groundItemLocation = event.getTile().getWorldLocation();
 
 		// Check that the item despawned on the same tile the player is on
-		if (!playerLocation.equals(groundItemLocation)) {
+		// Check that the item despawned on the same tile of telegrab target and same cycle telegrab 1ends
+		boolean playerPickUp = groundItemLocation.equals(playerLocation);
+		boolean telegrabOnItemTile = groundItemLocation.equals(telegrabEndTile);
+		// can be off by one tick depending on user running/dragged
+		boolean telegrabEndsOnCycle = Math.abs(telegrabPickUpCycle - client.getGameCycle()) <= 1;
+		boolean telegrabPickUp = telegrabOnItemTile && telegrabEndsOnCycle;
+
+		if (!(playerPickUp || telegrabPickUp)) {
 			return;
 		}
 

--- a/src/main/java/com/lootingbag/WildernessAgilityItems.java
+++ b/src/main/java/com/lootingbag/WildernessAgilityItems.java
@@ -1,0 +1,47 @@
+package com.lootingbag;
+
+import com.google.common.collect.ImmutableSet;
+import net.runelite.client.game.ItemManager;
+
+import java.util.HashMap;
+import static net.runelite.api.ItemID.*;
+
+public class WildernessAgilityItems {
+
+    private final ItemManager itemManager;
+    private final HashMap<String, Integer> nameToItemID = new HashMap<>();
+
+    public WildernessAgilityItems(ItemManager itemManager)
+    {
+        this.itemManager = itemManager;
+    }
+
+    // Items from https://oldschool.runescape.wiki/w/Agility_dispenser
+    static final ImmutableSet<Integer> ITEM_IDS = ImmutableSet.of(
+            // All Laps
+            BLIGHTED_ANGLERFISH, BLIGHTED_MANTA_RAY, BLIGHTED_KARAMBWAN, BLIGHTED_SUPER_RESTORE4,
+            MITHRIL_PLATESKIRT, MITHRIL_PLATELEGS, ADAMANT_PLATEBODY, RUNE_MED_HELM, ADAMANT_FULL_HELM, ADAMANT_PLATELEGS,
+
+            // Laps 1-15
+            STEEL_PLATEBODY,
+
+            // Lap 1-30
+            MITHRIL_CHAINBODY,
+
+            // Lap 16-60+
+            RUNE_CHAINBODY, RUNE_KITESHIELD
+    );
+
+    public Integer nameToItemId(String name) {
+        // All wildy agility items noted so get noted version
+        return itemManager.getItemComposition(nameToItemID.get(name)).getLinkedNoteId();
+    }
+
+    public void setupWildernessItemsIfEmpty() {
+        if (nameToItemID.isEmpty()) {
+            for (Integer itemID : ITEM_IDS) {
+                nameToItemID.put(itemManager.getItemComposition(itemID).getName(), itemID);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Updated version to 2.1.0
Added Lucid Poro to authors
Now works with wilderness agility dispenser

Addresses https://github.com/pwatts6060/runelite-plugins/issues/38 and https://github.com/pwatts6060/runelite-plugins/issues/36

Also
> Manually putting items from your inventory in the bag isn't supported.

this was updated in the previous update, however, README.md was not updated so I have updated it here.

If possible could you create the update plugin for plugin hub with the new commit? If not, I can create it myself, but I believe you would have to confirm the author change as well. Up to you, whichever you prefer.

You can also add me as collaborator, and I can handle the rest, similar to the other changes Nicole had previously