### PR TITLE
[looting-bag-value] Introduce High Alchemy Value setting

### DIFF
--- a/src/main/java/com/lootingbag/LootingBag.java
+++ b/src/main/java/com/lootingbag/LootingBag.java
@@ -148,6 +148,12 @@ public class LootingBag
 	}
 
 	private long getPriceOfItem(int itemId, int quantity) {
-		return itemManager.getItemPrice(itemId) * (long) quantity;
+		int itemValue = 0;
+		if (config.alchValue()) {
+			itemValue = itemManager.alchValue(itemId)
+		} else {
+			itemValue = itemManager.getItemPrice(itemId)
+		}
+		return itemValue * (long) quantity;
 	}
 }

--- a/src/main/java/com/lootingbag/LootingBagConfig.java
+++ b/src/main/java/com/lootingbag/LootingBagConfig.java
@@ -29,6 +29,15 @@ public interface LootingBagConfig extends Config
 	default boolean bagValue() {
 		return true;
 	}
+	
+	@ConfigItem(
+		keyName = "alchValue",
+		name = "High Alchemy Value",
+		description = "Use high alchemy value to determine bag value"
+	)
+	default boolean alchValue() {
+		return true;
+	}
 
 	@ConfigItem(
 		keyName = "freeSlots",

--- a/src/main/java/com/lootingbag/LootingBagConfig.java
+++ b/src/main/java/com/lootingbag/LootingBagConfig.java
@@ -36,7 +36,7 @@ public interface LootingBagConfig extends Config
 		description = "Use high alchemy value to determine bag value"
 	)
 	default boolean alchValue() {
-		return true;
+		return false;
 	}
 
 	@ConfigItem(


### PR DESCRIPTION
Introduce a new setting to the looting bag plugin - 'High Alchemy'.
This is a boolean setting. 

Enabling it will use `itemManager.alchValue` over `itemManager.getItemPrice` when fetching the price of an item. 