### PR TITLE
[looting-bag-value] Support Rogues' Chest loot

### DIFF
--- a/src/main/java/com/lootingbag/LootingBagPlugin.java
+++ b/src/main/java/com/lootingbag/LootingBagPlugin.java
@@ -46,6 +46,7 @@ import static net.runelite.api.gameval.InterfaceID.WILDERNESS_LOOTINGBAG;
 import net.runelite.api.gameval.InventoryID;
 import net.runelite.api.gameval.ItemID;
 import net.runelite.api.gameval.VarClientID;
+import net.runelite.api.gameval.VarbitID;
 import net.runelite.api.widgets.ComponentID;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.config.ConfigManager;
@@ -67,6 +68,8 @@ public class LootingBagPlugin extends Plugin
 
 	private static final Pattern WILDY_DISPENSER_REGEX = Pattern.compile("You have been awarded <[A-Za-z0-9=\\/]+>([\\d]+) x ([ a-zA-Z(4)]+)<[A-Za-z0-9=\\/]+> and <[A-Za-z0-9=\\/]+>([\\d]+) x ([ a-zA-Z]+)<[A-Za-z0-9=\\/]+> from the Agility dispenser.");
 	private static final Pattern WILDY_DISPENSER_EXTRA_REGEX = Pattern.compile("You have been awarded <[A-Za-z0-9=\\/]+>([\\d]+) x ([ a-zA-Z(4)]+)<[A-Za-z0-9=\\/]+> and <[A-Za-z0-9=\\/]+>([\\d]+) x ([ a-zA-Z]+)<[A-Za-z0-9=\\/]+>, and an extra <[A-Za-z0-9=\\/]+>[ a-zA-Z(4)]+<[A-Za-z0-9=\\/]+> from the Agility dispenser.");
+
+	private static final Pattern ROGUES_CHEST_REGEX = Pattern.compile("You find (?:a|some) ([A-Za-z]+(?: [A-Za-z]+)*) inside\\.");
 
 	private static final Map<String, Integer> AmountTextToInt = ImmutableMap.of(
 		"One", 1,
@@ -95,6 +98,9 @@ public class LootingBagPlugin extends Plugin
 
 	@Getter
 	private WildernessAgilityItems wildyItems;
+
+	@Getter
+	private RoguesChestItems roguesChestItems;
 
 	@Inject
 	private Gson gson;
@@ -128,6 +134,7 @@ public class LootingBagPlugin extends Plugin
 	{
 		lootingBag = new LootingBag(client, itemManager, lootingBagConfig);
 		wildyItems = new WildernessAgilityItems(itemManager);
+		roguesChestItems = new RoguesChestItems(itemManager);
 		overlayManager.add(overlay);
 		possibleSuppliesPickupActions = new ArrayList<>();
 	}
@@ -370,6 +377,16 @@ public class LootingBagPlugin extends Plugin
 				addWildernessItems(quantity, item, quantity2, item2);
 			}
 		}
+		else if (type == ChatMessageType.SPAM)
+		{
+			Matcher rogues_chest_matcher = ROGUES_CHEST_REGEX.matcher(message);
+
+			if (rogues_chest_matcher.matches()) {
+				String matchedItem = rogues_chest_matcher.group(1);
+				// log.debug("Looted from Rogues' Chest: " + matchedItem);
+				addRoguesChestItem(matchedItem);
+			}
+		}
 	}
 
 	private void addWildernessItems(int quantity, String itemName, int quantity2, String itemName2) {
@@ -384,6 +401,30 @@ public class LootingBagPlugin extends Plugin
 
 		lootingBag.addItem(itemId, quantity);
 		lootingBag.addItem(itemId2, quantity2);
+	}
+
+	private void addRoguesChestItem(String matchedItem) {
+		// Check if player has open looting bag in inventory
+		ItemContainer inventory = client.getItemContainer(InventoryID.INV);
+		if (inventory == null || !inventory.contains(ItemID.LOOTING_BAG_OPEN)) {
+			return;
+		}
+
+		// Get item from loot pool
+		Object[] chestLoot = roguesChestItems.getItemFromMatchedString(matchedItem);
+		if (chestLoot == null) { return; }
+
+		// Check for diary completion level
+		// chestLoot = { ITEM_ID, NOTED, COMMON_NAME, MEDIUM_DIARY_QUANTITY, HARD_DIARY_QUANTITY }
+		if (isWildernessHardDiaryComplete()) { // Hard diary complete
+			lootingBag.addItem((Integer) chestLoot[0], (Integer) chestLoot[4]);
+		} else { // Hard diary incomplete
+			lootingBag.addItem((Integer) chestLoot[0], (Integer) chestLoot[3]);
+		}
+	}
+
+	private boolean isWildernessHardDiaryComplete() {
+		return client.getVarbitValue(VarbitID.WILDERNESS_DIARY_HARD_COMPLETE) == 1;
 	}
 
 	private void handleInventoryUpdated(ItemContainer inventory) {

--- a/src/main/java/com/lootingbag/RoguesChestItems.java
+++ b/src/main/java/com/lootingbag/RoguesChestItems.java
@@ -1,0 +1,74 @@
+package com.lootingbag;
+
+import com.google.common.collect.ImmutableSet;
+import net.runelite.client.game.ItemManager;
+
+import static net.runelite.api.ItemID.*;
+
+public class RoguesChestItems {
+	private final ItemManager itemManager;
+	final ImmutableSet<Object[]> ITEM_POOL;
+
+	public RoguesChestItems(ItemManager itemManager)
+	{
+		this.itemManager = itemManager;
+
+		ITEM_POOL = ImmutableSet.of(
+			/*
+				[0] ITEM_ID
+				[1] NOTED (0/1)
+				[2] COMMON_NAME
+				[3] MEDIUM_DIARY_QUANTITY
+				[4] HARD_DIARY_QUANTITY
+			 */
+			// https://oldschool.runescape.wiki/w/Chest_(Rogues%27_Castle)
+			// "COMMON_NAME" field sourced/confirmed from in-game messages directly.
+
+			// The following items are gained from the chest *unnoted*.
+			new Object[] {NATURE_RUNE, 0, "nature runes", 40, 50},
+			new Object[] {LAW_RUNE, 0,"law runes", 40, 50},
+			new Object[] {COINS, 0, "coins", 4500, 5625},
+			new Object[] {BLIGHTED_ANCIENT_ICE_SACK, 0, "blighted ancient ice sacks", 13, 16},
+			new Object[] {PRAYER_POTION2, 0, "prayer potion", 1, 1},
+			new Object[] {CHAOS_RUNE, 0, "chaos runes", 60, 75},
+			new Object[] {DEATH_RUNE, 0, "death runes", 50, 62},
+
+			// The following items are gained from the chest *noted*.
+			new Object[] {RED_SPIDERS_EGGS, 1, "red spider eggs", 6, 7},
+			new Object[] {COAL, 1, "coal", 20, 25},
+			new Object[] {VILE_ASHES, 1, "vile ashes", 15, 18},
+			// NOTE: Uncut diamond can either be dropped at 3/5 for med diary,
+			// or 3/6 for hard diary. There is no way to distinguish these two
+			// drops from the chat, so we have to compromise here and just
+			// use the lower of the two drop values.
+			new Object[] {UNCUT_DIAMOND, 1, "uncut diamonds", 3, 3},
+			new Object[] {UNCUT_EMERALD, 1, "uncut emeralds", 10, 12},
+			new Object[] {IRON_ORE, 1, "iron ore", 40, 50},
+			new Object[] {BLIGHTED_MANTA_RAY, 1, "blighted manta rays", 20, 25},
+			new Object[] {BLIGHTED_ANGLERFISH, 1, "blighted anglerfish", 15, 18},
+			new Object[] {UNCUT_SAPPHIRE, 1, "uncut sapphires", 15, 18},
+			new Object[] {DRAGONSTONE, 1, "dragonstones", 2, 2}
+			// Clue scroll (hard) is ignored, can't be put in a looting bag
+		);
+	}
+
+	private Integer getNotedId(Integer id) {
+		return itemManager.getItemComposition(id).getLinkedNoteId();
+	}
+
+	public Object[] getItemFromMatchedString(String match) {
+		for (Object[] item : ITEM_POOL) {
+			String commonName = (String) item[2];
+			if (commonName.equals(match)) {
+				// Check if the item ID should be in noted form
+				if ((Integer) item[1] == 1) {
+					Object[] notedItem = item.clone();
+					notedItem[0] = getNotedId((Integer) item[0]);
+					return notedItem;
+				}
+				return item;
+			}
+		}
+		return null;
+	}
+}


### PR DESCRIPTION
## Support Rouges' Chest loot 

This PR adds a new `RoguesChestItems` class which manages and defines the loot pool available from thieving [Rogues' Chests](https://oldschool.runescape.wiki/w/Chest_(Rogues%27_Castle)/) in the Wilderness. This inclusion allows the looting bag to automatically update the estimate value while looting the chests, eliminating the need to stop and `M2 > Check` the bag to update the value so often.

- Changes made are similar to the update that added support for Wilderness Agility Course loot
- `COMMON_NAME`s for the available drops were sourced/confirmed from in-game messages directly
- Supports the 15-20% increase in loot from finishing the Wilderness Hard Diary (concrete values documented on wiki)

**One important caveat to note:** Uncut diamond can either be dropped at 3/5 quantity for medium diary or 3/6 quantity for hard diary and above. There is no way to distinguish these two drops from the chat, so a compromise is introduced to use the lower of the two drop values. This does mean the displayed value on the bag doesn't fully reflect the 2 (medium) to 3 (hard+) diamond difference--but this issue is mitigated when the bag is opened and values are recalculated. 

Video:

https://github.com/user-attachments/assets/ec46c269-67bb-4a1a-9a92-c605567915c7
